### PR TITLE
Bfloat16 support for use_xpos=True

### DIFF
--- a/rotary_embedding_torch/rotary_embedding_torch.py
+++ b/rotary_embedding_torch/rotary_embedding_torch.py
@@ -106,7 +106,7 @@ class RotaryEmbedding(nn.Module):
         device, dtype, seq_len = q.device, q.dtype, q.shape[seq_dim]
         seq = torch.arange(seq_len, dtype = dtype, device = device)
         freqs = self.forward(lambda: seq, cache_key = f'freqs:{seq_len}')
-        scale = self.get_scale(lambda: seq, cache_key = f'scale:{seq_len}')
+        scale = self.get_scale(lambda: seq, cache_key = f'scale:{seq_len}').to(dtype)
         rotated_q = apply_rotary_emb(freqs, q, scale = scale)
         rotated_k = apply_rotary_emb(freqs, k, scale = scale ** -1)
         return rotated_q, rotated_k

--- a/rotary_embedding_torch/rotary_embedding_torch.py
+++ b/rotary_embedding_torch/rotary_embedding_torch.py
@@ -103,8 +103,8 @@ class RotaryEmbedding(nn.Module):
 
     def rotate_queries_and_keys(self, q, k, seq_dim = -2):
         assert self.use_xpos
-        device, seq_len = q.device, q.shape[seq_dim]
-        seq = torch.arange(seq_len, device = device)
+        device, dtype, seq_len = q.device, q.dtype, q.shape[seq_dim]
+        seq = torch.arange(seq_len, dtype = dtype, device = device)
         freqs = self.forward(lambda: seq, cache_key = f'freqs:{seq_len}')
         scale = self.get_scale(lambda: seq, cache_key = f'scale:{seq_len}')
         rotated_q = apply_rotary_emb(freqs, q, scale = scale)


### PR DESCRIPTION
Good day @lucidrains,

Thank you very much for making rotary embeddings so easily available. :)

While using the library with bfloat16 tensors and `use_xpos = True`, I noticed that the dtype changes to float32.

This PR fixes this. In the [Colab](https://colab.research.google.com/drive/1uctY8j9FxT0EYL8khw2gmpGf6SJi9JXH?usp=sharing) you can see:
1. Properly working with `use_xpos=False` and keeping dtype bfloat16
2. Not functioning properly with `use_xpos=True`, because changing to dtype float32
3. After restarting the runtime, `use_xpos=True` keeping dtype bfloat16

Let me know if I need to adjust something.