### PR TITLE
Add sequence position interpolation to axial RoPE

### DIFF
--- a/rotary_embedding_torch/rotary_embedding_torch.py
+++ b/rotary_embedding_torch/rotary_embedding_torch.py
@@ -250,9 +250,9 @@ class RotaryEmbedding(Module):
 
         for ind, dim in enumerate(dims):
             if self.freqs_for == 'pixel':
-                pos = torch.linspace(-1, 1, steps = dim, device = self.device)
+                pos = torch.linspace(-1, 1, steps = dim, device = self.device) / self.interpolate_factor
             else:
-                pos = torch.arange(dim, device = self.device)
+                pos = torch.arange(dim, device = self.device) / self.interpolate_factor
 
             freqs = self.forward(pos, seq_len = dim)
 


### PR DESCRIPTION
Hi @lucidrains

This should allow us to do RoPE interpolation with the Axial variant. Let me know what you think.

The reasoning is that we interpolate in every dimension with the same factor (at the moment). If we change image size from 256x256 to 512x512, I think simply `2.0` will do the trick. If we want changes to aspect ratio from 256x256 to 1024x256 etc, we would need interpolation factor to be a tuple for each dim.

Thoughts?