### PR TITLE
Fix chi scale multiplication

### DIFF
--- a/rotary_embedding_torch/rotary_embedding_torch.py
+++ b/rotary_embedding_torch/rotary_embedding_torch.py
@@ -237,7 +237,7 @@ class RotaryEmbedding(Module):
         if self.use_xpos:
             power = (t - len(t) // 2) / self.scale_base
             scale = self.scale ** rearrange(power, 'n -> n 1')
-            scale = torch.cat((scale, scale), dim = -1)
+            scale = repeat(scale, 'n d -> n (d r)', r = 2)
 
         if should_cache:
             self.tmp_store('cached_scales', scale)


### PR DESCRIPTION
For `use_xpos=True`: 
The i-th 2x2 block should be scaled by the i-th chi/scale value. 
Previously, the scales were interleaved incorrectly, leading to differing results. 

One way to see the issue is to take a unit vector and plot its norm after being rotated:
![c4ffee4a-6017-4587-bca4-3205c927c854](https://github.com/user-attachments/assets/14deaf40-6993-42b8-b1ad-9141973d061c)

Now the reference implementation and this are consistent.